### PR TITLE
installation page: add Npackd packages to "windows" section

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -72,6 +72,8 @@ title: Installation
       = package_row '64-bit binary (by lachs0r)',
                     'http://mpv.srsfckn.biz/mpv-x86_64-latest.7z',
                     :"cloud-download"
+      = package_row 'Npackd 32-bit (lachs0r\'s release build)', 'https://npackd.appspot.com/p/io.mpv.mpv'
+      = package_row 'Npackd 64-bit (lachs0r\'s release build)', 'https://npackd.appspot.com/p/io.mpv.mpv-64'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
Just got mpv into the npackd (windows package manager). Add some links to the package descriptions (32/64 bit) on the installation page.
