### PR TITLE
Fix html validation error and delete unneded url parameter.

### DIFF
--- a/source/index.html.haml
+++ b/source/index.html.haml
@@ -1,7 +1,7 @@
 .jumbotron
   .container
     %h1
-      = image_tag "mpv-logo-128.png", width: "45px", height: "45px"
+      = image_tag "mpv-logo-128.png", width: "45", height: "45"
       mpv
     %p a free, open source, and cross-platform media player
     = image_tag "mpv-screenshot@2x.jpg", class: 'screenshot'

--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -33,7 +33,7 @@ title: Installation
               GNU/Linux packages
 
       = package_row 'Alpine', 'http://git.alpinelinux.org/cgit/aports/tree/main/mpv'
-      = package_row 'Arch (official)', 'https://www.archlinux.org/packages/?sort=&q=mpv'
+      = package_row 'Arch (official)', 'https://www.archlinux.org/packages/?q=mpv'
       = package_row 'Arch (aur, git package)', 'https://aur.archlinux.org/packages/mpv-git/'
       = package_row 'Arch (aur, mpv-build package)', 'https://aur.archlinux.org/packages/mpv-build-git/'
       = package_row 'CRUX', 'http://crux.nu/portdb/?a=search&q=mpv'

--- a/source/layouts/_navbar.html.haml
+++ b/source/layouts/_navbar.html.haml
@@ -3,7 +3,7 @@
     .navbar-header
       - unless homepage?
         %a.hidden-xs.navbar-brand{href: "/"}
-          = image_tag "mpv-logo-128.png", width: "40px", height: "40px"
+          = image_tag "mpv-logo-128.png", width: "40", height: "40"
           %span.title mpv
           %i.fa.fa-home
 


### PR DESCRIPTION
image_tag height and width parameters setting is incorrect.
Examples: http://apidock.com/rails/ActionView/Helpers/AssetTagHelper/image_tag.

Fixed validation error.
http://validator.w3.org/check?uri=mpv.io.

Delete unneded url parameter on archlinux package link.
