### PR TITLE
Fix website mistake

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -37,7 +37,7 @@ title: Installation
         %td(colspan="2")
           %h3
             %i.fa.fa-linux
-              GNU/Linux packages
+              Linux packages
 
       = package_row 'Alpine', 'http://git.alpinelinux.org/cgit/aports/tree/main/mpv'
       = package_row 'Arch (official)', 'https://www.archlinux.org/packages/?q=mpv'
@@ -61,7 +61,7 @@ title: Installation
         %td(colspan="2")
           %h3
             %i.fa.fa-linux
-              Outdated/unmaintained GNU/Linux packages
+              Outdated/unmaintained Linux packages
 
       = package_row 'Debian testing', 'https://packages.debian.org/testing/mpv'
       = package_row 'Fedora (RPM Fusion)', 'http://cvs.rpmfusion.org/viewvc/rpms/mpv/?root=free'


### PR DESCRIPTION
Alpine Linux use BusyBox instead of GNU CoreUtils, gcc isn't installed by default (you can opt for other compilers) and there's barely no GNU package.

As such, it's a Linux distribution, or a BusyBox/Linux distribution, or whatever you want to call it. But it isn't GNU/Linux.

There is one thing, though, that all distributions listed have in common: the Linux kernel. As such, I renamed it to "Linux packages" instead of "GNU Linux packages" to make it fit all case-scenarios.

Cheers.