### PR TITLE
Update getting_started

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ task :build_mpv_getting_started do
 end
 
 desc 'Generate site from Travis CI and publish site to GitHub Pages'
-task :travis => :build_mpv_manual do
+task :travis => [:build_mpv_manual, :build_mpv_getting_started] do
   # use public URL for clone
   system "git clone https://github.com/mpv-player/mpv-player.git build"
   system "bundle exec middleman build --verbose"

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,16 @@ task :build_mpv_manual do
   ].join(' '))
 end
 
+desc "Builds mpv's getting started guide"
+task :build_mpv_getting_started do
+  system([
+     rst2html,
+     '--template=rst2html_template',
+     'source/guides/getting-started.rst',
+     'source/guides/_getting-started.html.erb'
+     ].join(' '))
+end
+
 desc 'Generate site from Travis CI and publish site to GitHub Pages'
 task :travis => :build_mpv_manual do
   # use public URL for clone

--- a/source/guides/getting-started.html.haml
+++ b/source/guides/getting-started.html.haml
@@ -1,5 +1,7 @@
 .main-content
   .container
     .row
-      .col-lg-12#manual.manual-container
+      .col-lg-4.gettingstarted-navigation.visible-lg
+        .sticky(data-sticky-offset="20" data-navigation-source="#gettingstarted")
+      .col-lg-8#gettingstarted.gettingstarted-container
         = partial 'guides/getting-started.html.erb'

--- a/source/guides/getting-started.html.haml
+++ b/source/guides/getting-started.html.haml
@@ -1,0 +1,5 @@
+.main-content
+  .container
+    .row
+      .col-lg-12#manual.manual-container
+        = partial 'guides/getting-started.html.erb'

--- a/source/guides/getting-started.rst
+++ b/source/guides/getting-started.rst
@@ -24,6 +24,10 @@ Key bindings
 The key bindings can be found in the manpage. There's also a picture with all available key bindings and their actions:
 
 .. image:: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings.png
+   :height: 373px
+   :width: 625px
+   :target: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings.png
+   :alt: mpv key bindings
 
 Manpage
 =======

--- a/source/guides/getting-started.rst
+++ b/source/guides/getting-started.rst
@@ -18,6 +18,12 @@ For more info about Installing mpv check out the `related web page
 </installation>`_. Steps to compile the software are listed in mpv's and
 mpv-build's READMEs.
 
+Key bindings
+============
+The key bindings can be found in the manpage. There's also a picture with all available key bindings and their actions:
+
+.. image:: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings.png
+
 Manpage
 =======
 

--- a/source/guides/getting-started.rst
+++ b/source/guides/getting-started.rst
@@ -14,9 +14,10 @@ binaries are available on Windows and OS X. mpv can also be compiled from
 source on most UNIX systems: it is reported to work on BSDs (FreeBSD, OpenBSD
 and NetBSD) and Solaris.
 
-For more info about Installing mpv check out the `related web page
-</installation>`_. Steps to compile the software are listed in mpv's and
+For more info about Installing mpv check out the `related web page`_. Steps to compile the software are listed in mpv's and
 mpv-build's READMEs.
+
+.. _related web page: http://mpv.io/installation
 
 Key bindings
 ============
@@ -91,6 +92,6 @@ unsurprisingly, you can use: ::
   mpv --vo=opengl-hq:help
 
 For example, if you want to use the X11 backend to generate windows, and a
-color profile that matches my display, you would use: ::
+color profile that matches your display, you would use: ::
 
   mpv --vo=opengl-hq:backend=x11:icc-profile=path/to/icc/profile.icc

--- a/source/guides/getting-started.rst
+++ b/source/guides/getting-started.rst
@@ -23,10 +23,10 @@ Key bindings
 ============
 The key bindings can be found in the manpage. There's also a picture with all available key bindings and their actions:
 
-.. image:: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings.png
+.. image:: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings_compressed.png
    :height: 373px
    :width: 625px
-   :target: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings.png
+   :target: https://raw.githubusercontent.com/mpv-player/random-stuff/master/key_bindings_chart/mpbindings_compressed.png
    :alt: mpv key bindings
 
 Manpage

--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -112,15 +112,16 @@ title: Installation
     %h2 Installed successfully?
     %hr
     .row
-      // .col-xs-4
-      //   = link_to getting_started_path, class: "composite" do
-      //     %i.fa.fa-book.big-circle
-      //     %h3 Getting started guide
-      .col-xs-6
+      .col-xs-4
+        = link_to getting_started_path, class: "composite" do
+          %i.fa.fa-book.big-circle
+          %h3 Getting Started
+      .col-xs-4
         = link_to community_path, class: "composite" do
           %i.fa.fa-comments.big-circle
           %h3 Community
-      .col-xs-6
+      .col-xs-4
         = link_to bug_reports_path, class: "composite" do
           %i.fa.fa-bug.big-circle
           %h3 Nope (Report a bug)
+

--- a/source/manual.html.haml
+++ b/source/manual.html.haml
@@ -13,6 +13,20 @@ title: Reference manual
       understands, key bindings, scripting, and other customizations.
 
     %table.table.table-condensed
+
+      %tr
+        %td(colspan="2")
+          %h3
+            %i.fa.fa-check
+            Getting Started
+
+      %tr
+        %td Getting Sarted (incomplete, but being worked on)
+        %td(colspan="2")
+          = link_to getting_started_path do
+            %i.fa.fa-file-code-o
+            Getting Started
+
       %tr
         %td(colspan="2")
           %h3


### PR DESCRIPTION
I updated the getting_started with a picture of the default key bindings and fixed something small.

On a side note:

Wouldn't it be nice to have a button in the home page with getting started? Just like "Installation"? Maybe the getting_started guide can have a link to the Installation page too.
