### PR TITLE
build_mpv_manual: strip toc when calling rst2html

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,8 @@ task :build_mpv_manual do
   system([
     rst2html,
     '--template=rst2html_template',
+    '--strip-elements-with-class=contents',
+    '--no-toc-backlinks',
     'mpv/DOCS/man/mpv.rst',
     'source/manual/_master.html.erb'
   ].join(' '))
@@ -23,6 +25,8 @@ task :build_mpv_manual do
   system([
     rst2html,
     '--template=rst2html_template',
+    '--strip-elements-with-class=contents',
+    '--no-toc-backlinks',
     'mpv/DOCS/man/mpv.rst',
     'source/manual/_stable.html.erb'
   ].join(' '))


### PR DESCRIPTION
A TOC is being introduced to `mpv.rst` in mpv-player/mpv#3906. If merged, we need to strip the TOC from the manuals hosted on mpv.io, because we already have a navigation sidebar that serves as a sticky, interactive TOC.