### PR TITLE
Remove Homebrew from OS X installation methods

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -35,7 +35,6 @@ title: Installation
 
       = package_row 'OS X builds by stolendata', 'https://laboratory.stolendata.net/~djinn/mpv_osx/', :"cloud-download"
       = package_row 'Fink', 'http://pdb.finkproject.org/pdb/package.php/mpv'
-      = package_row 'Homebrew', 'https://github.com/Homebrew/homebrew-core/blob/master/Formula/mpv.rb'
       = package_row 'MacPorts', 'https://github.com/macports/macports-ports/blob/master/multimedia/mpv/Portfile'
 
       %tr


### PR DESCRIPTION
Homebrew broke their mpv formula and is [unwilling to fix it](https://0x0.st/sHJP.png). Remove defunct installation method from documentation to avoid user confusion.