### PR TITLE
Add a link to non-gnu.uvt.nl to the installation page

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -71,6 +71,7 @@ title: Installation
       = package_row 'Gentoo (official package)', 'https://packages.gentoo.org/packages/media-video/mpv'
       = package_row 'Ubuntu (PPA)', 'https://launchpad.net/~mc3man/+archive/ubuntu/mpv-tests'
       = package_row 'Ubuntu (PPA, with VapourSynth)', 'https://launchpad.net/%7Edjcj/+archive/ubuntu/vapoursynth'
+      = package_row 'Ubuntu and Debian (apt repository)', 'https://non-gnu.uvt.nl/debian'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
13:07 <j605> Fruit: may be you can list yours on mpv.io for time being

Unofficial packages built by Fruit, hosted by Tilburg University.
These packages include fribidi, shaderc, crossc, mujs.
This repository provides updates through the APT package management system.