### PR TITLE
Add a Ubuntu 18.04 PPA to the installation page

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -70,6 +70,7 @@ title: Installation
       = package_row 'Debian multimedia (unofficial)', 'http://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/mpv'
       = package_row 'Gentoo (official package)', 'https://packages.gentoo.org/packages/media-video/mpv'
       = package_row 'Ubuntu (PPA)', 'https://launchpad.net/~mc3man/+archive/ubuntu/mpv-tests'
+      = package_row 'Ubuntu 18.04 (bionic) PPA, (mpv with VapourSynth)', 'https://launchpad.net/~mc3man/+archive/ubuntu/bionic-media'
       = package_row 'Ubuntu and Debian (apt repository)', 'https://non-gnu.uvt.nl/debian'
 
       %tr


### PR DESCRIPTION
PPA for Ubuntu 18.04
Supports VapourSynth, which is required for some programs like SVP.