### PR TITLE
change Mac installation from homebrew to homebrew cask

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -35,7 +35,7 @@ title: Installation
 
       = package_row 'OS X builds by stolendata', 'https://laboratory.stolendata.net/~djinn/mpv_osx/', :"cloud-download"
       = package_row 'Fink', 'http://pdb.finkproject.org/pdb/package.php/mpv'
-      = package_row 'Homebrew', 'https://github.com/Homebrew/homebrew-core/blob/master/Formula/mpv.rb'
+      = package_row 'Homebrew Cask', 'https://github.com/Homebrew/homebrew-cask/blob/master/Casks/mpv.rb'
       = package_row 'MacPorts', 'https://github.com/macports/macports-ports/blob/master/multimedia/mpv/Portfile'
 
       %tr


### PR DESCRIPTION
mpv is removed from Homebrew-core https://github.com/Homebrew/homebrew-core/pull/44282 , now it is only available in homebrew cask