### PR TITLE
Update installation.html.haml

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -18,9 +18,12 @@ title: Installation
             %i.fa.fa-windows
             Windows
 
-      = package_row 'Windows builds by shinchiro (git) (unofficial)',
+      = package_row 'Windows builds by shinchiro (stable and git) (unofficial)',
                     'https://sourceforge.net/projects/mpv-player-windows/files',
                     :"cloud-download"
+      = package_row 'Scoop', 'https://github.com/lukesampson/scoop-extras/blob/master/bucket/mpv.json'
+      = package_row 'Scoop (git)', 'https://github.com/lukesampson/scoop-extras/blob/master/bucket/mpv-git.json'
+      = package_row 'Chocolatey', 'https://chocolatey.org/packages/mpv'
       = package_row 'Compilation instructions', 'https://github.com/mpv-player/mpv/blob/master/DOCS/compile-windows.md'
       = package_row 'MSYS2 source package', 'https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-mpv'
 


### PR DESCRIPTION
So, the official installation guide mentions Homebrew and apt-get but no mention of Scoop and Chocolatey packages. Also, shinchiro now also does stable builds for Windows.