### PR TITLE
add OS X nightly builds

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -37,9 +37,10 @@ title: Installation
           %p
             Unofficial third-party builds.
 
-      = package_row 'Homebrew', 'https://github.com/homebrew/homebrew-core/blob/master/Formula/mpv.rb'
       = package_row 'OS X builds by stolendata', 'https://laboratory.stolendata.net/~djinn/mpv_osx/', :"cloud-download"
+      = package_row 'OS X nightly builds by jnozsc', 'https://github.com/jnozsc/mpv-nightly-build', :"github-alt"
       = package_row 'MacPorts', 'https://github.com/macports/macports-ports/blob/master/multimedia/mpv/Portfile'
+      = package_row 'Homebrew (without OS X application bundles)', 'https://github.com/homebrew/homebrew-core/blob/master/Formula/mpv.rb'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
first of all, sorry for my bad git skill, have to close #81 again.

With your assistance from  #80 and #81 , I get my [nightly build](https://github.com/jnozsc/mpv-nightly-build) works with macOS `10.13` and `10.14` 

and on my README file, I clearly make a statement that I will support last 3 major release 

Thanks

cc @Akemi @Argon- 