### PR TITLE
Add viewport meta element to finally work on mobile.

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -2,6 +2,7 @@
 %html
   %head
     %meta(charset="utf-8")
+    %meta(name="viewport" content="width=device-width, initial-scale=1")
     %meta(content="IE=edge,chrome=1" http-equiv="X-UA-Compatible")
     %meta(name="description" content="a free, open source, and cross-platform media player")
     %meta(name="keywords" content="mpv, mplayer, download, media player, player download, encoder, video, video player, multimedia, multicast, Windows, Linux, Unix, BSD, Mac, macOS, OS X, OSX, Streaming, DVD, Matroska, MPEG, MPEG2, MPEG4, H264, DivX, MKV, m2ts, open source, free software, floss, free")


### PR DESCRIPTION
Now 📼 mpv.io 📼 will finally be 🌐 webscale 🌐, 📱mobile 📱🥇 first 🥇, and 🏦 enterprise 🏦 quality.

https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag