### PR TITLE
remove outdated/insecure PPA

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -73,7 +73,6 @@ title: Installation
       = package_row 'Arch (aur, mpv-build package)', 'https://aur.archlinux.org/packages/mpv-build-git/'
       = package_row 'Debian multimedia (unofficial)', 'http://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/mpv'
       = package_row 'Gentoo (official package)', 'https://packages.gentoo.org/packages/media-video/mpv'
-      = package_row 'Ubuntu (PPA)', 'https://launchpad.net/~mc3man/+archive/ubuntu/mpv-tests'
       = package_row 'Ubuntu and Debian (apt repository)', 'https://non-gnu.uvt.nl/debian'
 
       %tr


### PR DESCRIPTION
remove unofficial PPA, as the mpv version hosted there is vulnerable to [CVE-2021-30145](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-30145) and the [version currently in Ubuntu's repository](https://packages.ubuntu.com/impish/mpv) is newer anyway