### PR TITLE
Switch non-gnu.uvt.nl repository to apt.fruit.je

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -73,7 +73,7 @@ title: Installation
       = package_row 'Arch (aur, mpv-build package)', 'https://aur.archlinux.org/packages/mpv-build-git/'
       = package_row 'Debian multimedia (unofficial)', 'http://www.deb-multimedia.org/dists/testing/main/binary-amd64/package/mpv'
       = package_row 'Gentoo (official package)', 'https://packages.gentoo.org/packages/media-video/mpv'
-      = package_row 'Ubuntu and Debian (apt repository)', 'https://non-gnu.uvt.nl/debian'
+      = package_row 'Ubuntu and Debian (apt repository)', 'https://fruit.je/apt'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
The non-gnu.uvt.nl archive has trouble serving Ubuntu packages (caused by Ubuntu unilaterally deciding to introduce a new compression option in their fork of dpkg). apt.fruit.je does not have this issue.

Otherwise this repository has the same contents as the old one.