### PR TITLE
fix MSYS2 source package link

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -27,7 +27,7 @@ title: Installation
       = package_row 'Scoop (git)', 'https://github.com/lukesampson/scoop-extras/blob/master/bucket/mpv-git.json'
       = package_row 'Chocolatey', 'https://chocolatey.org/packages/mpv'
       = package_row 'Compilation instructions', 'https://github.com/mpv-player/mpv/blob/master/DOCS/compile-windows.md'
-      = package_row 'MSYS2 source package', 'https://github.com/Alexpux/MINGW-packages/tree/master/mingw-w64-mpv'
+      = package_row 'MSYS2 source package', 'https://github.com/msys2/MINGW-packages/tree/master/mingw-w64-mpv'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
Why did we use some random fork?