### PR TITLE
installation: Fix Homebrew link

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -40,7 +40,7 @@ title: Installation
       = package_row 'macOS builds by stolendata', 'https://laboratory.stolendata.net/~djinn/mpv_osx/', :"cloud-download"
       = package_row 'macOS nightly builds by jnozsc', 'https://github.com/jnozsc/mpv-nightly-build', :"github-alt"
       = package_row 'MacPorts', 'https://github.com/macports/macports-ports/blob/master/multimedia/mpv/Portfile'
-      = package_row 'Homebrew (without macOS application bundles)', 'https://github.com/homebrew/homebrew-core/blob/master/Formula/mpv.rb'
+      = package_row 'Homebrew (without macOS application bundles)', 'https://github.com/Homebrew/homebrew-core/blob/master/Formula/m/mpv.rb'
 
       %tr
         %td(colspan="2")


### PR DESCRIPTION
The link to installing on macOS with Homebrew was broken.