### PR TITLE
Remove link to outdated macOS builds.

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -38,7 +38,6 @@ title: Installation
             Unofficial third-party builds.
 
       = package_row 'macOS builds by stolendata', 'https://laboratory.stolendata.net/~djinn/mpv_osx/', :"cloud-download"
-      = package_row 'macOS nightly builds by jnozsc', 'https://github.com/jnozsc/mpv-nightly-build', :"github-alt"
       = package_row 'MacPorts', 'https://github.com/macports/macports-ports/blob/master/multimedia/mpv/Portfile'
       = package_row 'Homebrew (without macOS application bundles)', 'https://github.com/Homebrew/homebrew-core/blob/master/Formula/m/mpv.rb'
 


### PR DESCRIPTION
closes #110

----

Didn't test this because I couldn't find Docker image with Ruby 2.7 and Bundler but it should work fine.