### PR TITLE
Swap to `font-awesome-sass` over `font-awesome-middleman`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gem "middleman", "~> 3.4"
 gem "middleman-livereload", '>= 3.4', ' < 3.4.7'
 gem 'haml', '>= 4.0.5', '< 6.0' # compatible with legacy middleman
 gem "bootstrap-sass"
-gem "font-awesome-middleman"
+gem "font-awesome-sass", "< 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,8 @@ GEM
     eventmachine (1.2.7)
     execjs (2.9.1)
     ffi (1.16.3)
-    font-awesome-middleman (4.5.0)
-      middleman-core (~> 3.0)
+    font-awesome-sass (4.7.0)
+      sass (>= 3.2)
     haml (5.2.2)
       temple (>= 0.8.0)
       tilt
@@ -143,7 +143,7 @@ PLATFORMS
 
 DEPENDENCIES
   bootstrap-sass
-  font-awesome-middleman
+  font-awesome-sass (< 5.0)
   haml (>= 4.0.5, < 6.0)
   middleman (~> 3.4)
   middleman-livereload (>= 3.4, < 3.4.7)


### PR DESCRIPTION
`font-awesome-middleman` is completely abandoned and is pinning our middleman version to < 4. I pinned the sass version to under 5.0 for now, since letting that go to recent seemed to cause some sass issues.