### PR TITLE
Fixes broken link in  _overview.html.haml

### DIFF
--- a/source/_overview.html.haml
+++ b/source/_overview.html.haml
@@ -49,7 +49,7 @@
       Embeddable
     %p
       A straightforward
-      %a(href="https://github.com/mpv-player/mpv/blob/master/libmpv/client.h")C API
+      %a(href="https://github.com/mpv-player/mpv/blob/master/include/mpv/client.h")C API
       was designed from the ground up to make mpv usable as a library and
       facilitate easy integration into other applications.
 


### PR DESCRIPTION
Fixes the broken link to the embeddable version of mpv.