### PR TITLE
Add links to unofficial windows setup

### DIFF
--- a/source/installation.html.haml
+++ b/source/installation.html.haml
@@ -22,6 +22,12 @@ title: Installation
             The first-party CI builds are intended mainly for testing and may be
             missing certain features.
 
+      = package_row 'Windows Setup (stable, from shinchiro)',
+                    'https://github.com/mpv-distributions/mpv-windows-setup/releases/latest',
+                    :"cloud-download"
+      = package_row 'Windows Setup (git, from shinchiro)',
+                    'https://github.com/mpv-distributions/mpv-windows-setup/releases',
+                    :"cloud-download"
       = package_row 'Windows builds by shinchiro (git)',
                     'https://github.com/shinchiro/mpv-winbuild-cmake/releases',
                     :"cloud-download"


### PR DESCRIPTION
I have created a [Windows Setup for mpv](https://github.com/mpv-distributions/mpv-windows-setup). The features of the installer are described in the project’s [README](https://github.com/mpv-distributions/mpv-windows-setup/blob/main/README.md).

I would like to publish it on WinGet. The package will be named mpv unofficial. This is a stopgap until official WinGet packages become available. Microsoft requires that installer URLs be discoverable from the official publisher’s website in order to be accepted, hence this pr. 